### PR TITLE
Changed version/dist handling in build-deb.sh to not concat the distr…

### DIFF
--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -122,7 +122,8 @@ if [ "$USE_TIMESTAMP" == "true" ]; then
     fi
 fi
 
-VERSION=$(head -n1 debian/changelog  |awk -F [\(\)] '{print $2}')
+#VERSION=$(head -n1 debian/changelog  |awk -F [\(\)] '{print $2}') #W2 DB 1
+VERSION=$(head -n1 debian/changelog  |awk -F [\(\)] '{print $2}'|awk -F~ '{print $1}') #W2 DB 1
 DISTCODE=$(lsb_release -sc)
 
 if [ "$USE_TIMESTAMP" == "true" ]; then


### PR DESCRIPTION
The script did not extract the version number correctly after the first run, when the version was appended with the Ubuntu distribution name ~jammy. So subsequent runs of the script elongated the version name by one "~jammy" each time. 